### PR TITLE
Update mod dependency info for Forestry 4

### DIFF
--- a/src/net/bdew/neiaddons/NEIAddons.java
+++ b/src/net/bdew/neiaddons/NEIAddons.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
-@Mod(modid = NEIAddons.modId, name = "NEI Addons", version = "NEIADDONS_VER", dependencies = "after:NotEnoughItems")
+@Mod(modid = NEIAddons.modId, name = "NEI Addons", version = "NEIADDONS_VER", dependencies = "required-after:NotEnoughItems;after:Forestry@[4.0.8,);")
 public class NEIAddons {
 
     public static final String modId = "NEIAddons";


### PR DESCRIPTION
NEIAddons built for Forestry 4.0.8 will [crash](http://pastebin.com/1RrSx6pw) with earlier Forestry versions, so I'd like to add version dependency info.
